### PR TITLE
Closing memcached connections when SessionFactory.close is invoked

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.mihaicostin</groupId>
     <artifactId>hibernate-l2-memcached</artifactId>
-    <version>5.4.2.0</version>
+    <version>5.4.2.1</version>
     <name>hibernate-l2-memcached</name>
     <description>A library for using Memcached as a second level distributed cache in Hibernate.</description>
     <url>https://github.com/mihaicostin/hibernate-l2-memcached</url>

--- a/src/main/java/com/mc/hibernate/memcached/cache/CacheManager.java
+++ b/src/main/java/com/mc/hibernate/memcached/cache/CacheManager.java
@@ -55,6 +55,9 @@ public class CacheManager {
 
     public void releaseFromUse() {
         caches.clear();
+        if (client != null) {
+            client.shutdown();
+        }
     }
 
     public void addCache(String regionName) {


### PR DESCRIPTION
Without this patch, all memcached connections keep alive when the program finishes running, keeping alive the process on the OS. 