### PR TITLE
update for hibernate 6 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.github.mihaicostin</groupId>
     <artifactId>hibernate-l2-memcached</artifactId>
-    <version>5.4.2.1</version>
+    <version>6.2.1.Fork</version>
     <name>hibernate-l2-memcached</name>
     <description>A library for using Memcached as a second level distributed cache in Hibernate.</description>
     <url>https://github.com/mihaicostin/hibernate-l2-memcached</url>
@@ -39,7 +39,7 @@
     </distributionManagement>
 
     <properties>
-        <hibernate-core.version>5.4.24.Final</hibernate-core.version>
+        <hibernate-core.version>6.2.1.Final</hibernate-core.version>
         <spymemcached.version>2.12.3</spymemcached.version>
         <slf4j-api.version>1.5.6</slf4j-api.version>
 

--- a/src/main/java/com/mc/hibernate/memcached/MemcachedRegionFactory.java
+++ b/src/main/java/com/mc/hibernate/memcached/MemcachedRegionFactory.java
@@ -86,7 +86,7 @@ public class MemcachedRegionFactory extends RegionFactoryTemplate {
             // Maybe the user configured caches explicitly with legacy names; try them and use the first that exists
             for (String legacyDefaultRegionName : legacyDefaultRegionNames) {
                 if (cacheExists(legacyDefaultRegionName, sessionFactory)) {
-                    SecondLevelCacheLogger.INSTANCE.usingLegacyCacheName(defaultRegionName, legacyDefaultRegionName);
+                    SecondLevelCacheLogger.L2CACHE_LOGGER.usingLegacyCacheName(defaultRegionName, legacyDefaultRegionName);
                     return legacyDefaultRegionName;
                 }
             }

--- a/src/test/java/com/integration/com/mc/hibernate/memcached/CacheTimeout.java
+++ b/src/test/java/com/integration/com/mc/hibernate/memcached/CacheTimeout.java
@@ -23,7 +23,7 @@ public class CacheTimeout extends AbstractHibernateTestCase {
 
         Session session = sessionFactory.openSession();
         Transaction transaction = session.beginTransaction();
-        session.save(p);
+        session.persist(p);
         transaction.commit();
 
         session.get(Person.class, 10L);
@@ -50,7 +50,7 @@ public class CacheTimeout extends AbstractHibernateTestCase {
 
         Session session = sessionFactory.openSession();
         Transaction transaction = session.beginTransaction();
-        session.save(p);
+        session.persist(p);
         transaction.commit();
 
         session.get(Person.class, 101L);
@@ -75,7 +75,7 @@ public class CacheTimeout extends AbstractHibernateTestCase {
 
         Session session = sessionFactory.openSession();
         Transaction transaction = session.beginTransaction();
-        session.save(p);
+        session.persist(p);
         transaction.commit();
 
         session.get(Person.class, anneId);

--- a/src/test/java/com/integration/com/mc/hibernate/memcached/entities/Book.java
+++ b/src/test/java/com/integration/com/mc/hibernate/memcached/entities/Book.java
@@ -3,9 +3,9 @@ package com.integration.com.mc.hibernate.memcached.entities;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_ONLY)

--- a/src/test/java/com/integration/com/mc/hibernate/memcached/entities/Contact.java
+++ b/src/test/java/com/integration/com/mc/hibernate/memcached/entities/Contact.java
@@ -4,9 +4,11 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.annotations.Type;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import org.hibernate.usertype.UserType;
+
 import java.util.Date;
 
 @Entity
@@ -21,7 +23,6 @@ public class Contact {
 
     private String lastName;
 
-    @Type(type = "date")
     private Date birthday;
 
     public Long getId() {

--- a/src/test/java/com/integration/com/mc/hibernate/memcached/entities/Person.java
+++ b/src/test/java/com/integration/com/mc/hibernate/memcached/entities/Person.java
@@ -3,9 +3,9 @@ package com.integration.com.mc.hibernate.memcached.entities;
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
 
 @Entity
 @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)


### PR DESCRIPTION
What are your thoughts for Hibernate 6 compatibility?

I did an update that changed to the jakarta.* namespace instead of javax.* namespace and fixed a couple Hibernate 6 compatibility issues.     This also requires Java 17.   Tests all pass.

The catch is that it will now work with Hibernate 6 and Java 17 but not earlier versions of either.
